### PR TITLE
docs: 补全根目录 SUMMARY.md 导航（写作篇、AI 篇、单词表）

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -7,6 +7,8 @@
 * [3.听力篇](docs/threads/part-1/3-listening.md)
 * [4.阅读篇](docs/threads/part-1/4-reading.md)
 * [5.口语篇](docs/threads/part-1/5-speaking.md)
+* [6.写作篇](docs/threads/part-1/6-writing.md)
+* [7.利用 AI 学习（2026 版）](docs/threads/part-1/7-ai.md)
 
 
 ### Part II
@@ -17,3 +19,16 @@
 
 * [我的故事](docs/threads/part-2/my-story.md)
 * [Week 1](docs/threads/part-4/week-1.md)
+
+### 单词表（Word Lists）
+
+* [Common](docs/threads/word-list/Common.md)
+* [Go](docs/threads/word-list/Go.md)
+* [Java](docs/threads/word-list/Java.md)
+* [JavaScript](docs/threads/word-list/JavaScript.md)
+* [PHP](docs/threads/word-list/PHP.md)
+* [Prompt](docs/threads/word-list/Prompt.md)
+* [Python](docs/threads/word-list/Python.md)
+* [Swift](docs/threads/word-list/Swift.md)
+* [Rust](docs/threads/word-list/Rust.md)
+* [Vibe Coding (Agent)](docs/threads/word-list/VibeCoding.md)


### PR DESCRIPTION
## 背景

根目录的 `SUMMARY.md`（GitBook 导航）与 `docs/SUMMARY.md`（docsify 站点导航）不一致：

- 缺少 **第 6 章 · 写作篇**（`docs/threads/part-1/6-writing.md`）
- 缺少 **第 7 章 · 利用 AI 学习（2026 版）**（`docs/threads/part-1/7-ai.md`）
- 缺少整个 **单词表（Word Lists）** 章节（`docs/threads/word-list/*`）

对应的正文文件均已存在于仓库中，只是根目录导航未同步收录，导致通过 GitBook 浏览时看不到这几章。

## 改动

补齐 `SUMMARY.md` 中缺失的导航条目，使其与 `docs/SUMMARY.md` 保持一致：

- 在 Part I 增加写作篇、AI 篇
- 新增「单词表（Word Lists）」章节，列出 Common / Go / Java / JavaScript / PHP / Prompt / Python / Swift / Rust / Vibe Coding 等词表

仅改动文档导航，不涉及正文内容，所有链接均指向已存在的文件。